### PR TITLE
Added new Restcalls to check status of Server for Android app.

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -33,6 +33,7 @@ security:
     access_control:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/api/test, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/, roles: ROLE_USER }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/src/RestController/RestTestController.php
+++ b/src/RestController/RestTestController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\RestController;
+use FOS\RestBundle\Controller\Annotations as FOSRest;
+use FOS\RestBundle\Controller\FOSRestController;
+use FOS\RestBundle\View\View;
+use Symfony\Component\HttpFoundation\Response;
+
+
+class RestTestController extends FOSRestController
+{
+    /**
+     * @FOSRest\Get("/test")
+     */
+    public function testAvailability() {
+        return View::create("service available", Response::HTTP_OK , []);
+    }
+
+    /**
+     * @FOSRest\Get("/login")
+     */
+    public function testLogin() {
+        return View::create("login successful", Response::HTTP_OK , []);
+    }
+}

--- a/tests/Functional/AbstractWebTestCase.php
+++ b/tests/Functional/AbstractWebTestCase.php
@@ -10,6 +10,9 @@ class AbstractWebTestCase extends WebTestCase
     /** @var Client */
     public $client;
 
+    /** @var Client */
+    public $clientAnon;
+
     public function setUp()
     {
         $this->client = static::createClient(array(), array(
@@ -17,6 +20,9 @@ class AbstractWebTestCase extends WebTestCase
             'PHP_AUTH_PW' => 'supersecurepassword!',
         ));
         $this->client->catchExceptions(false);
+
+        $this->clientAnon = static::createClient();
+        $this->clientAnon->catchExceptions(false);
     }
 
     public function assertResponseContains(string $string): void

--- a/tests/Functional/RestTestControllerTest.php
+++ b/tests/Functional/RestTestControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Functional;
+
+class RestTestControllerTest extends AbstractWebTestCase
+{
+
+    public function testGetTest()
+    {
+        $this->clientAnon->request('GET', '/api/test');
+        $this->assertEquals(200, $this->clientAnon->getResponse()->getStatusCode());
+
+        $response = $this->clientAnon->getResponse()->getContent();
+        self::assertEquals('"service available"', $response);
+    }
+
+    public function testGetLogin()
+    {
+        $this->client->request('GET', '/api/login');
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $response = $this->client->getResponse()->getContent();
+        self::assertEquals('"login successful"', $response);
+    }
+
+}


### PR DESCRIPTION
The Call /api/test is used to check if the Android app uses the correct URL and the Call /api/login checks if the credentials are correct.