### PR TITLE
replaced duplication with doctrine command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ services:
 before_script:
   - composer install
   - composer require php-coveralls/php-coveralls
-  - rm .env
-  - echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/rezeptdb' >> .env
-  - echo 'APP_ENV=test' >> .env
-  - cat .env
   - php bin/console doctrine:database:create
   - cp phpunit.xml.dist phpunit.xml
   - php bin/console doctrine:migrations:migrate --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ services:
 before_script:
   - composer install
   - composer require php-coveralls/php-coveralls
-  - mysql -e 'CREATE DATABASE rezeptdb;'
   - rm .env
   - echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/rezeptdb' >> .env
   - echo 'APP_ENV=test' >> .env
   - cat .env
+  - php bin/console doctrine:database:create
   - cp phpunit.xml.dist phpunit.xml
   - php bin/console doctrine:migrations:migrate --no-interaction
   - php bin/console doctrine:fixtures:load --no-interaction


### PR DESCRIPTION
While working with the tests and looking into travis i have realized, that we can use the doctrine create command after we set the DATABASE_URL. This ensures that the correct database was created.

Additionally I think we can use 
echo 'DATABASE_URL=$DATABASE_URL' >> .env 
instead of using the current
echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/rezeptdb' >> .env

It might be even be possible to completely remove this line, since travis already sets this variable in the setup.
Can you look into this?